### PR TITLE
add Simplified  Chinese translation

### DIFF
--- a/src/main/resources/assets/elementaristics/lang/zh_cn.json
+++ b/src/main/resources/assets/elementaristics/lang/zh_cn.json
@@ -1,0 +1,12 @@
+{
+  "comment_1": "ITEMS",
+  "item.elementaristics.liber_elementium": "自由：源质之书",
+  "item.elementaristics.liber_elementium.rite": "自由：源质之书 (仪式模式)",
+
+
+  "comment_9": "COMMAND STUFF",
+  "elementaristics.command.set_magan.success": "切换 %s 的游戏模式为  %d",
+  "comment_10": "BOOK STUFF",
+  "elementaristics.book.name": "自由：源质之书",
+  "elementaristics.book.landing": "Putting the square in the circle"
+}


### PR DESCRIPTION
I'm so glad to see you update this mod finally, we have almost finished the Chinese translation of 1.12.2 version, but it seems that the 1.12.2 repository had been deleted already.  Fortunately, we have another way to let Chinese people can use the translation, so don't worry. I also want to know what mc version is this repository for?
BTW, I wonder if I could repost your mod to mcbbs, which is the most popular Minecraft forum in China. 

I will do these things:

1. Introduce your mod in Chinese
2. give an address that links to the curseforge page for downloading this mod

I won't do these things:

1. give a private download address for player to download
2. claim that this mod is made by myself.

I will appreciate it if you give me this permission, and also thanks for your work in the Minecraft mod community.